### PR TITLE
do not require types for parameters and return

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,6 +17,7 @@ module.exports = {
     ],
     "@typescript-eslint/no-var-requires": "off",
     "no-unused-expressions": "off",
-    "node/no-unsupported-features/es-syntax": "off"
+    "node/no-unsupported-features/es-syntax": "off",
+    "valid-jsdoc": ["warn", { "requireReturnType": false, "requireParamType": false }]
   }
 }


### PR DESCRIPTION
`valid-jsdoc eslint` rule requires explicit types for parameters and return types. However TypeScript and therefore TypeDoc infers types from source code and defining types with JSDoc is redundant.

Below code should be valid JSDoc for TypeScript.

```
/**
 * Some description
 *
 * @param cmd is some string.
 * @returns some string.
 */
export default function command(cmd: string): string {
  return cmd
}
```