### PR TITLE
BREAKING CHANGE: update deps to latest eslint stuff

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,10 +21,10 @@ jobs:
     <<: *test
     docker:
       - image: node:12
-  node-10:
+  node-14:
     <<: *test
     docker:
-      - image: node:10
+      - image: node:14
   release:
     <<: *test
     steps:
@@ -53,13 +53,13 @@ workflows:
   "eslint-config-oclif-typescript":
     jobs:
       - node-latest
+      - node-14
       - node-12
-      - node-10
       - release:
           context: org-global
           filters:
             branches: {only: master}
           requires:
             - node-latest
+            - node-14
             - node-12
-            - node-10

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,7 +58,7 @@ workflows:
       - release:
           context: org-global
           filters:
-            branches: {only: master}
+            branches: {only: main}
           requires:
             - node-latest
             - node-14

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        node-version: [10.x, 12.x]
+        node-version: [14.x, 12.x]
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node-version }}

--- a/package.json
+++ b/package.json
@@ -5,19 +5,19 @@
   "author": "oclif",
   "bugs": "https://github.com/oclif/eslint-config-oclif-typescript/issues",
   "dependencies": {
-    "@typescript-eslint/eslint-plugin": "^2.6.1",
-    "@typescript-eslint/parser": "^2.6.1",
+    "@typescript-eslint/eslint-plugin": "^4",
+    "@typescript-eslint/parser": "^4",
     "eslint-config-xo-space": "^0.27.0",
     "eslint-plugin-mocha": "^6.3.0",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-unicorn": "^19.0.1"
   },
   "devDependencies": {
-    "eslint": "^6.8.0",
-    "typescript": "3.8.3"
+    "eslint": "^7",
+    "typescript": "^4"
   },
   "engines": {
-    "node": ">= 10.0.0"
+    "node": ">= 12.0.0"
   },
   "files": [
     "/index.js"


### PR DESCRIPTION
Fixes incompatibility issues between the newer version of eslint that updated `oclif` repos are using and `@typescript-eslint/parser`/`@typescript-eslint/eslint-plugin`.

See https://github.com/typescript-eslint/typescript-eslint/issues/2446 for more info.
This will fix the broken `lint` build on https://github.com/oclif/oclif/pull/672