### PR TITLE
Copy .gitignore from eslint-config-oclif

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,6 @@
-node_modules/
+*-debug.log
+*-error.log
+/coverage
+/coverage.lcov
+/node_modules
+/tmp


### PR DESCRIPTION
Current `.gitignore` does not actually ignore `node_modules`.