### PR TITLE
updated dependencies to latest versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,15 +5,15 @@
   "author": "oclif",
   "bugs": "https://github.com/oclif/eslint-config-oclif-typescript/issues",
   "dependencies": {
-    "@typescript-eslint/eslint-plugin": "^4.31.2",
-    "@typescript-eslint/parser": "^4.31.2",
-    "eslint-config-xo-space": "^0.29.0",
-    "eslint-plugin-mocha": "^9.0.0",
+    "@typescript-eslint/eslint-plugin": "^5.45.0",
+    "@typescript-eslint/parser": "^5.45.0",
+    "eslint-config-xo-space": "^0.34.0",
+    "eslint-plugin-mocha": "^10.1.0",
     "eslint-plugin-node": "^11.1.0"
   },
   "devDependencies": {
-    "eslint": "^7.32.0",
-    "typescript": "^4"
+    "eslint": "^8.29.0",
+    "typescript": "^4.9.3"
   },
   "engines": {
     "node": ">=12.0.0"


### PR DESCRIPTION
updating both of  @typescript-eslint plugins will allow to use eslint ^8.0.0

in order to be full up to date I updated all depenencies