### PR TITLE
fix: use typescript-eslint/no-useless-constructor

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,6 +10,8 @@ module.exports = {
   parser: '@typescript-eslint/parser',
   plugins: ['@typescript-eslint', 'import'],
   rules: {
+    'no-useless-constructor': 'off',
+    '@typescript-eslint/no-useless-constructor': 'error',
     '@typescript-eslint/no-unused-vars': [
       'error',
       {

--- a/index.js
+++ b/index.js
@@ -10,17 +10,17 @@ module.exports = {
   parser: '@typescript-eslint/parser',
   plugins: ['@typescript-eslint', 'import'],
   rules: {
-    'no-useless-constructor': 'off',
-    '@typescript-eslint/no-useless-constructor': 'error',
     '@typescript-eslint/no-unused-vars': [
       'error',
       {
         argsIgnorePattern: '^_',
       },
     ],
+    '@typescript-eslint/no-useless-constructor': 'error',
     '@typescript-eslint/no-var-requires': 'off',
     'import/no-unresolved': 'error',
     'no-unused-expressions': 'off',
+    'no-useless-constructor': 'off',
     'node/no-missing-import': 'off',
     'node/no-unsupported-features/es-syntax': 'off',
     'perfectionist/sort-classes': [


### PR DESCRIPTION
Use `@typescript-eslint/no-useless-constructor` instead of generic `no-useless-constructor`

Fixes #22 